### PR TITLE
[FE] 폴더별 게시글 리스트 보기 페이지 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ function App() {
         <Routes>
           <Route path={PATH.MAIN} element={<MainPage page={Pages.ALL_POST} />} />
           <Route path={PATH.BOOKMARK} element={<MainPage page={Pages.BOOKMARK} />} />
+          <Route path={PATH.FOLDER} element={<MainPage page={Pages.FOLDER} />} />
           <Route path={PATH.SUBSCRIBE} element={<MainPage page={Pages.SUBSCRIBE} />} />
           <Route path={PATH.SETTING.FOLDERS} element={<MainPage page={Pages.SET_FOLDERS} />} />
           <Route path={PATH.AUTH.LOGIN} element={<LoginPage />} />

--- a/src/component/content/FolderPostListContent copy.tsx
+++ b/src/component/content/FolderPostListContent copy.tsx
@@ -1,0 +1,68 @@
+import { useEffect, useState } from "react";
+import { Post } from "./post/PostType";
+import { API_PATH } from "../../constants/ApiPath";
+import PostItemList from "./post/PostItemList";
+import authAxios from "../../utill/ApiUtills";
+
+type Props = {
+  folderId: number,
+}
+
+export default function FolderPostListContent({folderId}: Props) {
+
+  let timeoutId: number;
+
+  const [page, setPage] = useState<number>(0);
+  const [posts, setPosts] = useState<Post[]>([]);
+
+  useEffect(() => {
+    getAllPosts(0);
+  }, []);
+
+  // api call
+  const getAllPosts = async (page: number) => {
+    authAxios
+      .get(API_PATH.FOLDER.POST.GET_ALL(folderId), {
+        params: {
+          page: page,
+        },
+      })
+      .then(function (response) {
+        if (response.status == 200) {
+          const newPosts = response.data.data.posts;
+          setPosts([...posts, ...newPosts]);
+        } else {
+          throw new Error("Request failed: " + response.status);
+        }
+      });
+  };
+
+  // infinite-scroller
+  const handleScroll = () => {
+    const { scrollTop, clientHeight, scrollHeight } = document.documentElement;
+
+    // 스크롤이 화면 맨 밑에 닿았을 경우
+    if (scrollTop + clientHeight >= scrollHeight - 10) {
+      // 기존에 설정된 타임아웃을 클리어
+      clearTimeout(timeoutId);
+
+      // 1초 후에 추가 데이터 로드
+      timeoutId = setTimeout(() => {
+        getAllPosts(page + 1);
+        setPage(page + 1);
+      }, 1000);
+    }
+  };
+
+  useEffect(() => {
+    window.addEventListener("scroll", handleScroll);
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+      clearTimeout(timeoutId);
+    };
+  }, [posts, page]);
+
+  return (
+    <PostItemList posts={posts} />
+  );
+}

--- a/src/component/layout/sidebar/SideBarType.ts
+++ b/src/component/layout/sidebar/SideBarType.ts
@@ -16,4 +16,5 @@ export type Folder = {
   unreadCount: number;
   blogs: Blog[];
   invitedMembers: InvitedMember[];
+  isOpen: boolean;
 };

--- a/src/component/layout/sidebar/SideFolderTree.tsx
+++ b/src/component/layout/sidebar/SideFolderTree.tsx
@@ -2,6 +2,7 @@ import { useNavigate } from "react-router-dom";
 import { Icon } from "../../common/Icon";
 import { Folder } from "./SideBarType";
 import { PATH } from "../../../constants/Path";
+import { useFoldersStore } from "../../../store/store";
 
 type Props = {
   title?: string;
@@ -9,7 +10,7 @@ type Props = {
 };
 
 export default function SideFolderTree({ title, folders }: Props) {
-  
+  const { openFolder, closeFolder } = useFoldersStore();
   const navigate = useNavigate();
   const goToSubscribePosts = (subscribeId: number, subscribeTitle: string) => {
     navigate(PATH.SUBSCRIBE, {
@@ -23,28 +24,42 @@ export default function SideFolderTree({ title, folders }: Props) {
   return (
     <>
       <div className="text-lg font-bold">{title || "이름 없음"}</div>
+
       <ul className="menu w-70 rounded-box">
-        <li>
-          {folders && folders.length > 0 ? (
-            folders.map((folder) => (
-              <details>
-                <summary>
-                  <Icon name="folder" />
+        {folders && folders.length > 0 ? (
+          folders.map((folder) => (
+            <li>
+              <span>
+                <Icon name="folder" />
+                <span>
                   {folder.name}
-                </summary>
-                <ul>
-                  {folder.blogs.map((blog) => (
-                    <li>
-                      <a onClick={() => goToSubscribePosts(blog.id, blog.title)}>{blog.title}</a>
-                    </li>
-                  ))}
-                </ul>
-              </details>
-            ))
-          ) : (
+                </span>
+                <span
+                  onClick={
+                    folder.isOpen
+                      ? () => closeFolder(folder.id)
+                      : () => openFolder(folder.id)
+                  }
+                >
+                  {folder.isOpen ? "▲" : "▼"}
+                </span>
+              </span>
+              <ul className={`menu-dropdown ${folder.isOpen ? 'menu-dropdown-show' : ''}`}>
+                {folder.blogs.map((blog) => (
+                  <li>
+                    <a onClick={() => goToSubscribePosts(blog.id, blog.title)}>
+                      {blog.title}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </li>
+          ))
+        ) : (
+          <li>
             <p>폴더가 없습니다.</p>
-          )}
-        </li>
+          </li>
+        )}
       </ul>
     </>
   );

--- a/src/component/layout/sidebar/SideFolderTree.tsx
+++ b/src/component/layout/sidebar/SideFolderTree.tsx
@@ -20,6 +20,14 @@ export default function SideFolderTree({ title, folders }: Props) {
       },
     });
   };
+  const goToFolderPosts = (folderId: number, folderTitle: string) => {
+    navigate(PATH.FOLDER, {
+      state: {
+        folderId: folderId,
+        folderTitle: folderTitle,
+      },
+    });
+  };
 
   return (
     <>
@@ -31,7 +39,7 @@ export default function SideFolderTree({ title, folders }: Props) {
             <li>
               <span>
                 <Icon name="folder" />
-                <span>
+                <span onClick={() => goToFolderPosts(folder.id, folder.name)}>
                   {folder.name}
                 </span>
                 <span

--- a/src/constants/ApiPath.ts
+++ b/src/constants/ApiPath.ts
@@ -24,6 +24,9 @@ export const API_PATH = {
     SUBSCRIBE: {
       ADD: (folderId: number) => `/folders/${folderId}/rss`,
       DELETE: (folderId: number, folderSubscribeId: number) => `/folders/${folderId}/rss/${folderSubscribeId}`
+    },
+    POST: {
+      GET_ALL: (folderId: number) => `/folders/${folderId}/posts`,
     }
   },
   MEMBER: {

--- a/src/constants/Pages.tsx
+++ b/src/constants/Pages.tsx
@@ -1,6 +1,7 @@
 export enum Pages {
   ALL_POST = "전체 보기",
   BOOKMARK = "북마크",
+  FOLDER = "폴더",
   SUBSCRIBE = "블로그",
   SET_FOLDERS = "폴더 관리",
 }

--- a/src/constants/Path.ts
+++ b/src/constants/Path.ts
@@ -1,6 +1,7 @@
 export const PATH = {
   MAIN: "/",
   BOOKMARK: "/bookmark",
+  FOLDER: "/folder",
   SUBSCRIBE: "/subscribe",
   SETTING: {
     FOLDERS: "/setting/folders"

--- a/src/page/MainPage.tsx
+++ b/src/page/MainPage.tsx
@@ -12,6 +12,7 @@ import { StoredMemberInfo } from "./auth/AuthType";
 import Header from "../component/layout/header/Header";
 import authAxios from "../utill/ApiUtills";
 import { useFoldersStore } from "../store/store";
+import FolderPostListContent from "../component/content/FolderPostListContent copy";
 
 type Props = {
   page: Pages;
@@ -58,6 +59,15 @@ export default function MainPage({ page }: Props) {
     }
     case Pages.BOOKMARK: {
       content = <BookmarkListContent />;
+      break;
+    }
+    case Pages.FOLDER: {
+      const data = location.state;
+      headerTitle = data.folderTitle;
+      key = data.folderId;
+      content = (
+        <FolderPostListContent key={key} folderId={data.folderId} />
+      );
       break;
     }
     case Pages.SUBSCRIBE: {

--- a/src/page/MainPage.tsx
+++ b/src/page/MainPage.tsx
@@ -24,7 +24,7 @@ export default function MainPage({ page }: Props) {
   let content: ReactNode;
   let key: number = 0;
 
-  const { setPrivateFolders, setSharedFolders } = useFoldersStore();
+  const { setPrivateFolders, setSharedFolders, isEmpty } = useFoldersStore();
   const [memberInfo, setMemberInfo] = useState<StoredMemberInfo | null>(null);
   const navigate = useNavigate();
 
@@ -38,17 +38,19 @@ export default function MainPage({ page }: Props) {
       return;
     }
 
-    authAxios
-      .get(API_PATH.FOLDER.GET_ALL)
-      .then(function (response) {
-        if (response.status == 200) {
-          const folders = response.data.data.folders;
-          setPrivateFolders(folders.PRIVATE);
-          setSharedFolders(folders.SHARED);
-        } else {
-          throw new Error("Request failed: " + response.status);
-        }
-      });
+    if (isEmpty()) {
+      authAxios
+        .get(API_PATH.FOLDER.GET_ALL)
+        .then(function (response) {
+          if (response.status == 200) {
+            const folders = response.data.data.folders;
+            setPrivateFolders(folders.PRIVATE);
+            setSharedFolders(folders.SHARED);
+          } else {
+            throw new Error("Request failed: " + response.status);
+          }
+        });
+    }
 
   }, [navigate, setPrivateFolders, setSharedFolders]);
 

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -10,15 +10,27 @@ type FoldersStoreType = {
   addFolderToSharedFolders: (newFolder: Folder) => void;
   updateFolder: (updatedFolder: Folder) => void;
   deleteFolder: (folderId: number) => void;
+  openFolder: (folderId: number) => void;
+  closeFolder: (folderId: number) => void;
 };
 
 export const useFoldersStore = create<FoldersStoreType>((set) => ({
   privateFolders: [],
   sharedFolders: [],
   setPrivateFolders: (folders: Folder[]) =>
-    set(() => ({ privateFolders: [...folders] })),
+    set(() => ({
+      privateFolders: folders.map((folder) => ({
+        ...folder,
+        isOpen: folder.isOpen ?? false,
+      }))
+    })),
   setSharedFolders: (folders: Folder[]) =>
-    set(() => ({ sharedFolders: [...folders] })),
+    set(() => ({
+      sharedFolders: folders.map((folder) => ({
+        ...folder,
+        isOpen: folder.isOpen ?? false,
+      }))
+    })),
   addFolderToPrivateFolders: (newFolder: Folder) =>
     set((prev) => ({ privateFolders: [...prev.privateFolders, newFolder] })),
   addFolderToSharedFolders: (newFolder: Folder) =>
@@ -81,16 +93,16 @@ export const useFoldersStore = create<FoldersStoreType>((set) => ({
         const folderIndex: number = prev.sharedFolders.findIndex(
           (f) => f.id == updatedFolder.id
         );
-  
+
         if (folderIndex !== -1) {
           prev.sharedFolders[folderIndex] = updatedFolder;
-  
+
           return { sharedFolders: [...prev.sharedFolders] };
         } else {
           return { sharedFolders: [...prev.sharedFolders, updatedFolder] };
         }
       }
-      
+
       return prev;
     });
   },
@@ -99,14 +111,62 @@ export const useFoldersStore = create<FoldersStoreType>((set) => ({
       prev.privateFolders = prev.privateFolders.filter(
         (f) => f.id !== folderId
       );
+      prev.sharedFolders = prev.sharedFolders.filter((f) => f.id !== folderId);
+
+      return {
+        privateFolders: [...prev.privateFolders],
+        sharedFolders: [...prev.sharedFolders],
+      };
+    });
+  },
+  openFolder: (folderId: number) => {
+    set((prev) => {
+      prev.privateFolders = prev.privateFolders.map(
+        (folder) => {
+          if (folder.id === folderId) {
+            return { ...folder, isOpen: true };
+          }
+          return folder;
+        }
+      );
       prev.sharedFolders = prev.sharedFolders.filter(
-        (f) => f.id !== folderId
+        (folder) => {
+          if (folder.id === folderId) {
+            return { ...folder, isOpen: true };
+          }
+          return folder;
+        }
       );
 
       return {
         privateFolders: [...prev.privateFolders],
         sharedFolders: [...prev.sharedFolders],
       };
-    })
+    });
+  },
+  closeFolder: (folderId: number) => {
+    set((prev) => {
+      prev.privateFolders = prev.privateFolders.map(
+        (folder) => {
+          if (folder.id === folderId) {
+            return { ...folder, isOpen: false };
+          }
+          return folder;
+        }
+      );
+      prev.sharedFolders = prev.sharedFolders.filter(
+        (folder) => {
+          if (folder.id === folderId) {
+            return { ...folder, isOpen: false };
+          }
+          return folder;
+        }
+      );
+
+      return {
+        privateFolders: [...prev.privateFolders],
+        sharedFolders: [...prev.sharedFolders],
+      };
+    });
   },
 }));

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -12,9 +12,10 @@ type FoldersStoreType = {
   deleteFolder: (folderId: number) => void;
   openFolder: (folderId: number) => void;
   closeFolder: (folderId: number) => void;
+  isEmpty: () => boolean;
 };
 
-export const useFoldersStore = create<FoldersStoreType>((set) => ({
+export const useFoldersStore = create<FoldersStoreType>((set, get) => ({
   privateFolders: [],
   sharedFolders: [],
   setPrivateFolders: (folders: Folder[]) =>
@@ -169,4 +170,8 @@ export const useFoldersStore = create<FoldersStoreType>((set) => ({
       };
     });
   },
+  isEmpty: () => {
+    const state = get();
+    return state.privateFolders.length == 0 && state.sharedFolders.length == 0;
+  }
 }));


### PR DESCRIPTION
## 🔑 Key Changes
- 폴더별 게시글 리스트 보기 페이지 추가
- 사이드바 폴더 트리에서 폴더 열기 버튼을 클릭해야 폴더 트리가 열리도록 변경

## 👩‍💻 To Reviewers
![rss get folder post list](https://github.com/FlytrapHub/RSS-Reader-FE/assets/86359180/3aa1e81d-1193-40ed-8985-2af0f7dd8c95)


## Related to
- closes #48 