### PR TITLE
[FE] post modal에 css 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import "./App.css";
+import "./PostContent.css";
 import LoginPage from './page/auth/LoginPage';
 import GitHubCallbackPage from './page/auth/GitHubCallbackPage';
 import { PATH } from './constants/Path';

--- a/src/PostContent.css
+++ b/src/PostContent.css
@@ -1,0 +1,56 @@
+.post-content-css * {
+    text-align: left;
+}
+
+.post-content-css ul li {
+    list-style-type: disc; /* 기본 원형 불릿 적용 */
+}
+
+.post-content-css li {
+    padding-left: 10px; /* 내용과 불릿을 20px 만큼 들여쓰기 */
+    list-style-position: inside; /* 불릿을 내용의 안쪽으로 위치 */
+}
+
+.post-content-css h1,
+.post-content-css h2,
+.post-content-css h3 {
+    font-weight: bold;
+}
+
+.post-content-css h1 {
+    font-size: 32px;
+    margin-top: 15px;
+}
+
+.post-content-css h2 {
+    font-size: 28px;
+    margin-top: 10px;
+}
+
+.post-content-css h3 {
+    font-size: 24px;
+    margin-top: 10px;
+}
+
+.post-content-css code {
+    background-color: #f9f9f9; /* 연한 회색 배경 */
+    border: 1px solid #ccc; /* 경계선 */
+    border-radius: 3px; /* 경계선 둥글게 */
+    padding: 2px 4px; /* 상하, 좌우 패딩 */
+    font-family: 'Courier New', Courier, monospace; /* 고정폭 글꼴 */
+    font-size: 0.9em; /* 상대적 글꼴 크기 */
+    color: #d14; /* 글자색 */
+}
+
+.post-content-css pre > code {
+    background-color: #f4f4f4; /* 밝은 회색 배경 */
+    border: 1px solid #ddd; /* 경계선 */
+    border-radius: 4px; /* 경계선 둥글게 */
+    padding: 5px 10px; /* 상하, 좌우 패딩 */
+    font-family: 'Courier New', Courier, monospace; /* 고정폭 글꼴 */
+    font-size: 16px; /* 글꼴 크기 */
+    color: #333; /* 글자색 */
+    display: block; /* 블록 요소로 표시 */
+    overflow-x: auto; /* 가로 스크롤바 필요시 표시 */
+    white-space: pre-wrap; /* 공백과 줄바꿈 유지 */
+}

--- a/src/component/content/post/PostModal.tsx
+++ b/src/component/content/post/PostModal.tsx
@@ -19,15 +19,15 @@ export default function PostModal({ post, setPostForModal }: Props) {
         >
           ✕
         </button>
-        <h3 className="font-bold text-lg">{post.title}</h3>
-        <p>
+        <h3 className="font-bold text-4xl">{post.title}</h3>
+        <p className="text-blue-500 hover:text-blue-700 cursor-pointer">
           <a href={post.guid} target="_blank">
             {post.guid}
           </a>
         </p>
         <p>{post.pubDate}</p>
         <div className="py-4">
-          <div
+          <div className="post-content-css"
             dangerouslySetInnerHTML={{ __html: post.description }}
           >
         </div>


### PR DESCRIPTION
## 🔑 Key Changes
- post modal에 css 추가
  - h1, h2, h3
  - 텍스트 왼쪽 정렬
  - li에 불릿 찍기
  - 코드 스크립트 박스 스타일 적용
  - 블로그 링크 파란색으로 변경

## 👩‍💻 To Reviewers
<img width="1002" alt="image" src="https://github.com/FlytrapHub/RSS-Reader-FE/assets/86359180/dfbea414-9c69-4b51-b26a-6635ece9e8b7">

## Related to
- #60 