### PR TITLE
[FE] 레이아웃 UI 개선: 로고 위치 수정, 메뉴 아이콘 수정

### DIFF
--- a/src/common/asset/stack.svg
+++ b/src/common/asset/stack.svg
@@ -1,3 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" className="inline-block w-5 h-5 stroke-current">
-  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 6h16M4 12h16M4 18h16">
-</path>
+<?xml version="1.0" encoding="utf-8"?><!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg" fill="none">
+  <path fill="#000000" fill-rule="evenodd" d="M19 4a1 1 0 01-1 1H2a1 1 0 010-2h16a1 1 0 011 1zm0 6a1 1 0 01-1 1H2a1 1 0 110-2h16a1 1 0 011 1zm-1 7a1 1 0 100-2H2a1 1 0 100 2h16z"/>
+</svg>

--- a/src/domain/layout/component/header/Header.tsx
+++ b/src/domain/layout/component/header/Header.tsx
@@ -54,7 +54,7 @@ export default function Header({ title, memberInfo, setMemberInfo }: Props) {
             {memberInfo != null ? (
               <div className="w-10 rounded-full">
                 <img
-                  alt="Tailwind CSS Navbar component"
+                  alt="User Profile Image"
                   src={memberInfo && memberInfo.profile}
                 />
               </div>

--- a/src/domain/layout/component/sidebar/SideBar.tsx
+++ b/src/domain/layout/component/sidebar/SideBar.tsx
@@ -1,4 +1,3 @@
-import SideLogo from "./SideLogo";
 import SideMenu from "./SideMenu";
 
 export default function SideBar() {
@@ -9,8 +8,6 @@ export default function SideBar() {
         aria-label="close sidebar"
         className="drawer-overlay"
       ></label>
-
-      <SideLogo />
 
       <SideMenu />
     </>

--- a/src/domain/layout/component/sidebar/SideMenu.tsx
+++ b/src/domain/layout/component/sidebar/SideMenu.tsx
@@ -2,6 +2,7 @@ import { PATH } from "@common/constant/Path";
 import { useFoldersStore } from "@common/store/FoldersStore";
 import SideFolderTree from "./SideFolderTree";
 import { useNavigate } from "react-router-dom";
+import SideLogo from "./SideLogo";
 
 export default function SideMenu() {
   const { privateFolders, sharedFolders } = useFoldersStore();
@@ -12,6 +13,7 @@ export default function SideMenu() {
 
   return (
     <ul className="menu p-4 w-80 min-h-full bg-base-200 text-base-content gap-2">
+      <SideLogo />
       <li>
         <a className="btn btn-success text-lg" onClick={() => goToPage(PATH.MAIN)}>전체 보기</a>
       </li>


### PR DESCRIPTION
## 🔑 Key Changes
- 

## 👩‍💻 To Reviewers
## 로고 위치 수정

**변경 전**
<img width="617" alt="image" src="https://github.com/FlytrapHub/RSS-Reader-FE/assets/86359180/4fed6b83-b428-48ef-97d5-baa879b286f8">

**변경 후**
<img width="498" alt="image" src="https://github.com/FlytrapHub/RSS-Reader-FE/assets/86359180/1fb27c05-0a55-435c-ad92-f13b7682e191">


## 메뉴 아이콘 수정

**변경 전**
<img width="455" alt="image" src="https://github.com/FlytrapHub/RSS-Reader-FE/assets/86359180/742b9ca0-f55b-401a-b8cf-1a047ebe51e3">

**변경 후**
<img width="232" alt="image" src="https://github.com/FlytrapHub/RSS-Reader-FE/assets/86359180/50d7df2b-7a24-400f-bddb-4d9e8d651ae7">
- svg 파일이 깨진 파일이였던 것 같다. 파일을  열어보니 깨져 있었다. 그런데 왜 처음에는 잘 나왔지?? 값자기 파일이 깨질 이유가 있나...

## Related to
- #69 